### PR TITLE
fix(docx): use explicit @d6e-ai/docx import so runtime injects the library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,3 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - STF `render-invoice-docx` for Word document generation with MS Gothic font.
 - Optional issuer logo embedding (PNG / JPEG via base64) for both PDF and DOCX.
 - Reference files: requirements guide, tax rate master, and input JSON template.
+
+### Fixed
+
+- `render-invoice-docx` STF now uses an explicit
+  `import { ... } from '@d6e-ai/docx';` statement instead of bare
+  `const { ... } = docx;`. The d6e QuickJS runtime only injects
+  `@d6e-ai/*` libraries when it sees a literal `import` statement in
+  the STF source, so the previous form failed at execution time with a
+  `docx is not defined` error.

--- a/stfs/render-invoice-docx.js
+++ b/stfs/render-invoice-docx.js
@@ -7,8 +7,17 @@
 // payment terms, and notes.
 //
 // Return: { file_data: <base64>, file_name: <string> }
+//
+// Important: the d6e QuickJS runtime injects @d6e-ai libraries only when
+// it sees a literal `import ... from "@d6e-ai/<lib>"` statement in the STF
+// source. Referencing `docx` through `const { ... } = docx;` without an
+// import statement leaves the library unloaded and results in a
+// 'docx is not defined' error at execution time. The explicit named import
+// below is required; the runtime rewrites it to
+// `const { ... } = globalThis.docx;` internally so downstream code is
+// unchanged.
 
-const {
+import {
   Document,
   Packer,
   Paragraph,
@@ -26,7 +35,7 @@ const {
   VerticalAlign,
   PageNumber,
   HeadingLevel,
-} = docx;
+} from '@d6e-ai/docx';
 
 // --- helpers ---------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Replace `const { ... } = docx;` with a real `import { ... } from '@d6e-ai/docx';` in `stfs/render-invoice-docx.js`.
- Add an inline comment documenting the runtime constraint so future edits do not regress.
- Add a `Fixed` entry to `CHANGELOG.md` under `Unreleased v1.0.0`.

Closes #3

## Why

End-to-end testing in a live workspace showed the installed
`render-invoice-docx` STF failing with a `docx is not defined` error.
The d6e QuickJS runtime only injects `@d6e-ai/*` libraries when it
sees literal `import ... from "@d6e-ai/<lib>"` statements in the STF
source (see `packages/api/src/engine/runtime_js.rs` — `D6E_IMPORT_RE`
and `parse_d6e_imports`). Without an explicit import, `docx` is never
pushed onto `globalThis`, and the STF crashes at execution.

The runtime rewrites `import { ... } from "@d6e-ai/docx"` to
`const { ... } = globalThis.docx;`, so no downstream code needs to
change. Only `render-invoice-docx.js` was affected; the PDF renderer
already used `import fontkit from '@d6e-ai/fontkit';` etc., and the
validator has no external library dependencies.

## Test plan

- [x] `node -c` equivalent: strip imports, wrap in async IIFE, and run through `new Function(...)`. All three STFs parse cleanly.
- [ ] Install the app into a test workspace and run the three document
      types (qualified / simplified / return) with the same payloads
      that previously failed.
- [ ] Confirm the generated `.docx` opens in Word / LibreOffice and
      matches the PDF layout visually.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is limited to the DOCX STF import mechanism and changelog, with no business-logic or data-handling modifications.
> 
> **Overview**
> Fixes the `render-invoice-docx` STF failing at runtime with `docx is not defined` by replacing the implicit `docx` destructure with an explicit `import { ... } from '@d6e-ai/docx';` that triggers library injection in the d6e QuickJS runtime.
> 
> Adds an inline comment to prevent future regressions and records the fix in `CHANGELOG.md` under *Unreleased*.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 658ab6797490fbb44be6000694e4aae5ba14ebc8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->