### PR TITLE
fix: PDF payload handling, per-format workflows, and filename sanitization

### DIFF
--- a/.plans/pdf-payload-and-workflow.plan.md
+++ b/.plans/pdf-payload-and-workflow.plan.md
@@ -1,0 +1,84 @@
+# PDF payload 受け取り・ワークフロー連携・入力形式統一の修正プラン
+
+Relates to: d6e-ai/d6e-app-invoice-jp#5
+
+## 目的
+
+v1.0.0 の end-to-end テストで確認された、以下の不具合をすべて解消する。
+
+- `render-invoice-pdf` が空 / ¥0 の PDF を生成してしまう
+- PDF ファイル名が `適格請求書_undated.pdf` になり書類番号が反映されない
+- AI が想定していた `generate-invoice-files` ワークフローが実は存在しない
+- 3 STF の入力形式（`$input` / ラップ形式）がケースによってずれ、エージェントがワークアラウンドで凌いでいる
+
+## 前提
+
+d6e ランタイムの仕様を `packages/api/src/engine/runtime_js.rs` と
+`packages/api/src/engine/{workflow,context,input_resolver}.rs` で確認済み。
+
+- `$input` は STF 実行時にランタイムが直接 `globalThis.$input` にセットする（`runtime_js.rs` L717-721）。
+- ワークフローは `input_steps` → `stf_steps`（順次） → `effect_steps`（並列）で実行される（`workflow.rs` L49-119）。
+- field mapping のパスは `$input.xxx` / `$steps[n].xxx` / `$sources.name.xxx` のいずれかの **`$` プレフィックス必須** 形式（`context.rs` L45-80、`packages/skills/d6e-workflow/SKILL.md` L77 で明記）。
+- installer はマッピングの `value` を変換せずそのまま API に渡す（`packages/frontend/src/lib/server/app-installer.ts` L504-507）。
+
+## 変更点
+
+### 1. `template.yaml`
+
+- **`validate-qualified-invoice` の input_schema** を単一の権威定義とし、`render-invoice-pdf` / `render-invoice-docx` の input_schema にも同じ完全形スキーマをコピーして揃える。
+  - 3 箇所のコピーを維持する必要があるので、各 STF の直上に `# Keep this schema in sync with validate-qualified-invoice.` というコメントを置いて、将来のズレを防ぐ。
+  - `required` は validate と同じ `[document_type, transaction_date, issuer, items]` のまま。
+- **`workflows:` ブロックを追加**し、`generate-invoice-files` を定義する。
+  - step 0: `validate-qualified-invoice`。`input_mappings` で `$input.<field>` を各 target に 13 個マッピング（全必須 + 任意フィールド）。
+  - step 1: `render-invoice-pdf`。`input_mappings` で `$steps[0].normalized_payload.<field>` を各 target にマッピング。
+  - step 2: `render-invoice-docx`。同じマッピングをもう一度書く（ワークフロー step は順次実行だが、どちらを先にしても結果は同じ）。
+  - ワークフロー全体の戻り値は最後の step の出力になるため、この並びだと DOCX の `{file_data, file_name}` が返る。呼び出し元が両方欲しい場合は AI が `$steps[1].file_*` / `$steps[2].file_*` を利用する想定。ただし現在の d6e はワークフロー戻り値が last step のみなので、`template_prompt` 内で「ワークフロー実行後、step 1 と 2 の両方の file_data をユーザーに提示する」指示を明確化する。
+- **`template_prompt`** を以下のように書き換える。
+  - これまでの「validate を呼んで、normalized_payload を render に渡す」手続き指示を外し、**`generate-invoice-files` ワークフローを第一選択**とする。
+  - ワークフロー実行結果が `valid: false` の場合は validate step のエラーをユーザーに提示して再入力を依頼。
+  - 稀に片方だけ欲しい場合（PDF だけなど）のみ、STF を単体で呼ぶフォールバック手順を残す。
+
+### 2. `stfs/render-invoice-pdf.js`
+
+- **ファイル名生成ロジック** を以下の優先順位に変更する。
+  1. `payload.document_number` があり、サニタイズ後も長さ > 0 ならそれを採用
+  2. なければ `payload.transaction_date`（`YYYY-MM-DD` → `YYYYMMDD`）
+  3. それも無ければ `payload.issue_date` を同様に整形
+  4. どれも無ければ `'undated'`
+- **サニタイズ** は `/[\\/:*?"<>|\\s]/g` を `_` に置換し、連続アンダーバーをつぶす。さらに先頭末尾の `_` を trim して、最大 80 文字に切り詰める。
+- **payload unwrap フォールバック** を追加する。
+  - `$input.normalized_payload` が オブジェクトなら `payload = $input.normalized_payload` にする（AI が validate の戻り値をそのまま投げたケース）。
+  - ワークフローからの呼び出しでは input_mappings が直接 payload フィールドを並べるので、このフォールバックは通らない。
+- これらの変更は `// --- input resolution ---` セクションに集約し、コメントで「ワークフロー経由 / 手動呼び出しの両方に対応」と明記する。
+
+### 3. `stfs/render-invoice-docx.js`
+
+- PDF と**同一**のファイル名生成 / payload unwrap ロジックに置き換える。共通関数は抽出できない（STF は1ファイル1実行単位）ので、両ファイルに同じ実装をコピーし、コメントで「render-invoice-pdf.js と同期させる」と明記。
+
+### 4. `stfs/validate-qualified-invoice.js`
+
+- 現状は `$input` から直接受け取って `normalized_payload` を返している。ワークフロー内でも `$input.xxx` から直接フィールドが渡されるため、修正不要。
+- 念のため、`$input.normalized_payload`  ラップで来た場合も対応する同じ unwrap フォールバックを入れる（対称性のため）。
+
+### 5. `README.md` / `CHANGELOG.md`
+
+- README の「使い方」セクションに `generate-invoice-files` ワークフローが第一推奨であることを追記。
+- CHANGELOG の Unreleased v1.0.0 に以下を追記:
+  - Fixed: PDF payload not being received
+  - Fixed: filename falling back to `undated` even when document_number exists
+  - Added: `generate-invoice-files` workflow
+  - Changed: render STF input_schema expanded to full payload shape
+
+## 検証
+
+- `/tmp/d6e-validate/check-stfs.js` で 3 STF の構文を再チェック。
+- `ajv` で template.yaml を template.schema.json に対して再検証（既に存在する流れを再利用）。
+- 手元で validate STF に「テスト payload（書類番号 `INV-TEST-20260422-004`、取引日 `2026-04-22`）」を `$input` として渡して `normalized_payload` が想定通りのものを返すか、Node 単体実行で簡易確認（STF コードを import 剥がして wrapper で包む形）。
+
+## 非スコープ
+
+以下は本 Issue では扱わない。
+
+- simplified_invoice / return_invoice のテスト実施そのもの（本修正後に別タスクで再テスト）。
+- ワークフロー戻り値に全 step 出力を含める機能強化（d6e 本体側の話）。
+- workflow の step 並列実行化（`workflow.rs` の STF 並列化改修）。

--- a/.plans/pdf-payload-and-workflow.plan.md
+++ b/.plans/pdf-payload-and-workflow.plan.md
@@ -28,15 +28,16 @@ d6e ランタイムの仕様を `packages/api/src/engine/runtime_js.rs` と
 - **`validate-qualified-invoice` の input_schema** を単一の権威定義とし、`render-invoice-pdf` / `render-invoice-docx` の input_schema にも同じ完全形スキーマをコピーして揃える。
   - 3 箇所のコピーを維持する必要があるので、各 STF の直上に `# Keep this schema in sync with validate-qualified-invoice.` というコメントを置いて、将来のズレを防ぐ。
   - `required` は validate と同じ `[document_type, transaction_date, issuer, items]` のまま。
-- **`workflows:` ブロックを追加**し、`generate-invoice-files` を定義する。
-  - step 0: `validate-qualified-invoice`。`input_mappings` で `$input.<field>` を各 target に 13 個マッピング（全必須 + 任意フィールド）。
-  - step 1: `render-invoice-pdf`。`input_mappings` で `$steps[0].normalized_payload.<field>` を各 target にマッピング。
-  - step 2: `render-invoice-docx`。同じマッピングをもう一度書く（ワークフロー step は順次実行だが、どちらを先にしても結果は同じ）。
-  - ワークフロー全体の戻り値は最後の step の出力になるため、この並びだと DOCX の `{file_data, file_name}` が返る。呼び出し元が両方欲しい場合は AI が `$steps[1].file_*` / `$steps[2].file_*` を利用する想定。ただし現在の d6e はワークフロー戻り値が last step のみなので、`template_prompt` 内で「ワークフロー実行後、step 1 と 2 の両方の file_data をユーザーに提示する」指示を明確化する。
+- **`workflows:` ブロックを追加**し、以下 2 本のワークフローを定義する。`d6e` の `execute_workflow` は最後の STF 出力のみを戻り値として返し、`binary-detection.ts` の `extractBinaryFromResult` も 1 つの `file_data` しか抽出できない。単一ワークフローで PDF と DOCX を同時に返すことは現状の API / UI では実現不可能。よって、**ユーザーが欲しい形式ごとに独立したワークフローを提供**し、AI がそれらを順次呼び分ける形にする。
+  - `generate-invoice-pdf`: validate-qualified-invoice → render-invoice-pdf（last step → PDF の `{file_data, file_name}` が戻り値）。
+  - `generate-invoice-docx`: validate-qualified-invoice → render-invoice-docx（last step → DOCX の `{file_data, file_name}` が戻り値）。
+  - 両ワークフローとも step 0 の `input_mappings` は `$input.<field>` を 13 個（全フィールド）。step 1 の `input_mappings` は `$steps[0].normalized_payload.<field>` を 13 個。
+  - validate が失敗（`$steps[0].valid === false`）した場合、render step にはエラー時の `normalized_payload: null` が渡るので、render STF 側で payload が空オブジェクトに近い状態になる。このケースは AI がワークフロー実行前に直接 validate を一度呼んでエラーを提示するのが理想。`template_prompt` で明示する。
 - **`template_prompt`** を以下のように書き換える。
-  - これまでの「validate を呼んで、normalized_payload を render に渡す」手続き指示を外し、**`generate-invoice-files` ワークフローを第一選択**とする。
-  - ワークフロー実行結果が `valid: false` の場合は validate step のエラーをユーザーに提示して再入力を依頼。
-  - 稀に片方だけ欲しい場合（PDF だけなど）のみ、STF を単体で呼ぶフォールバック手順を残す。
+  - これまでの「validate を呼んで、normalized_payload を render に渡す」手続き指示を外し、**ワークフロー呼び出しを第一選択**にする。
+  - 両方の形式（PDF + DOCX）が欲しい場合は **事前に `validate-qualified-invoice` を 1 回だけ単体実行** してエラーをユーザーに提示 → 問題なければ `generate-invoice-pdf` と `generate-invoice-docx` を**両方**呼ぶ、という流れを明示する。validate を単体で先に呼ぶことで、万が一エラーがあっても不要な PDF / DOCX 生成を回避でき、かつ2 本のワークフローで validate が二重に走ることのオーバーヘッドも「エラー無しが確認済み」なので許容できる範囲に収まる。
+  - PDF だけ（または DOCX だけ）欲しい場合は対応するワークフローを 1 本だけ呼ぶ。
+  - 直接 STF を手動で連結する呼び出し方はフォールバックとして残すが、第一推奨からは外す。
 
 ### 2. `stfs/render-invoice-pdf.js`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,3 +28,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `@d6e-ai/*` libraries when it sees a literal `import` statement in
   the STF source, so the previous form failed at execution time with a
   `docx is not defined` error.
+- `render-invoice-pdf` and `render-invoice-docx` now unwrap
+  `$input.normalized_payload` before reading any fields. This prevents
+  blank PDF / DOCX output when an AI agent forwards the full
+  `validate-qualified-invoice` response (including the `valid`,
+  `errors`, and `normalized_payload` keys) rather than the flat payload.
+- Generated file names now prefer `document_number` (sanitized for
+  filesystem-illegal characters), then fall back to `transaction_date`,
+  `issue_date`, and finally `undated`. Previously the file name relied
+  on `transaction_date` alone, so downloads surfaced as
+  `適格請求書_undated.pdf` whenever the date field was missing even
+  though a document number was available.
+
+### Added
+
+- Two new workflows, `generate-invoice-pdf` and `generate-invoice-docx`,
+  that validate the payload and render the invoice in a single
+  deterministic run. Because d6e workflow return values are limited to
+  the last STF output, the two formats are exposed as separate
+  workflows and the AI calls both when the user wants both files.
+
+### Changed
+
+- `input_schema` of `render-invoice-pdf` and `render-invoice-docx`
+  expanded from a four-field stub to the full invoice payload shape
+  (kept in sync with `validate-qualified-invoice`). This gives LLM
+  tool-callers complete field-level hints and lets runtime schema
+  validation catch missing required fields before rendering.
+- `template_prompt` now instructs the AI to prefer the new workflows
+  over manually chaining the three STFs. Manual chaining remains
+  available as a fallback for partial runs (e.g. validation only).

--- a/stfs/render-invoice-docx.js
+++ b/stfs/render-invoice-docx.js
@@ -214,7 +214,24 @@ function makeTextCell(text, width, align, extraRuns) {
 
 // --- input + totals --------------------------------------------------------
 
-const payload = $input || {};
+// The d6e JS runtime injects the caller-provided input as the `$input` global.
+// Accept both shapes for resilience — these must stay in lock-step with
+// render-invoice-pdf.js so that workflow calls and direct AI invocations
+// behave identically for both output formats:
+//   1. Direct payload ({ document_type, items, ... }) — produced by the
+//      generate-invoice-docx workflow's input_mappings.
+//   2. Wrapped form ({ normalized_payload: { ... } }) — produced when an AI
+//      agent forwards the full `validate-qualified-invoice` result without
+//      unwrapping.
+let payload = $input && typeof $input === 'object' ? $input : {};
+if (
+  payload.normalized_payload &&
+  typeof payload.normalized_payload === 'object' &&
+  !Array.isArray(payload.normalized_payload)
+) {
+  payload = payload.normalized_payload;
+}
+
 const documentType = payload.document_type || 'qualified_invoice';
 const DOCUMENT_TYPE_META = {
   qualified_invoice: { title: '適格請求書', filePrefix: '適格請求書' },
@@ -729,10 +746,50 @@ const doc = new Document({
 });
 
 const base64 = await Packer.toBase64String(doc);
-const dateForName =
-  typeof payload.transaction_date === 'string'
-    ? payload.transaction_date.replace(/-/g, '')
-    : 'undated';
-const fileName = meta.filePrefix + '_' + dateForName + '.docx';
+const fileName = meta.filePrefix + '_' + buildFileNameSuffix(payload) + '.docx';
 
 return { file_data: base64, file_name: fileName };
+
+// Build the trailing part of the generated file name.
+// Priority: document_number (sanitized) > transaction_date > issue_date > 'undated'.
+// Keep this logic byte-identical with render-invoice-pdf.js so PDF and DOCX
+// downloads always share the same file stem for a given invoice.
+function buildFileNameSuffix(p) {
+  const fromDocNumber = sanitizeForFileName(p && p.document_number);
+  if (fromDocNumber) {
+    return fromDocNumber;
+  }
+  const fromTxDate = ymdCompact(p && p.transaction_date);
+  if (fromTxDate) {
+    return fromTxDate;
+  }
+  const fromIssueDate = ymdCompact(p && p.issue_date);
+  if (fromIssueDate) {
+    return fromIssueDate;
+  }
+  return 'undated';
+}
+
+function sanitizeForFileName(raw) {
+  if (typeof raw !== 'string') {
+    return '';
+  }
+  const replaced = raw.replace(/[\\/:*?"<>|\s\x00-\x1f]/g, '_');
+  const collapsed = replaced.replace(/_+/g, '_');
+  const trimmed = collapsed.replace(/^_+|_+$/g, '');
+  if (trimmed.length === 0) {
+    return '';
+  }
+  return trimmed.length > 80 ? trimmed.slice(0, 80) : trimmed;
+}
+
+function ymdCompact(raw) {
+  if (typeof raw !== 'string') {
+    return '';
+  }
+  const match = raw.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (!match) {
+    return '';
+  }
+  return match[1] + match[2] + match[3];
+}

--- a/stfs/render-invoice-pdf.js
+++ b/stfs/render-invoice-pdf.js
@@ -121,7 +121,26 @@ function wrapText(text, font, fontSize, maxWidth) {
 
 // --- input and metadata ----------------------------------------------------
 
-const payload = $input || {};
+// The d6e JS runtime injects the caller-provided input as the `$input` global.
+// Accept both shapes for resilience:
+//   1. Direct payload ({ document_type, items, ... }) — produced by the
+//      generate-invoice-pdf workflow's input_mappings and by AI agents that
+//      already pass a flattened payload.
+//   2. Wrapped form ({ normalized_payload: { ... } }) — produced when an AI
+//      agent accidentally forwards the full `validate-qualified-invoice`
+//      result without unwrapping.
+// The unwrap below keeps the downstream code (which assumes a flat payload)
+// unchanged, and prevents the "PDF body is empty / totals are zero" failure
+// we hit in the v1.0.0 end-to-end test.
+let payload = $input && typeof $input === 'object' ? $input : {};
+if (
+  payload.normalized_payload &&
+  typeof payload.normalized_payload === 'object' &&
+  !Array.isArray(payload.normalized_payload)
+) {
+  payload = payload.normalized_payload;
+}
+
 const documentType = payload.document_type || 'qualified_invoice';
 
 const DOCUMENT_TYPE_META = {
@@ -628,10 +647,57 @@ drawText(
 // --- Output ----------------------------------------------------------------
 
 const base64 = await pdfDoc.saveAsBase64();
-const dateForName =
-  typeof payload.transaction_date === 'string'
-    ? payload.transaction_date.replace(/-/g, '')
-    : 'undated';
-const fileName = meta.filePrefix + '_' + dateForName + '.pdf';
+const fileName = meta.filePrefix + '_' + buildFileNameSuffix(payload) + '.pdf';
 
 return { file_data: base64, file_name: fileName };
+
+// Build the trailing part of the generated file name.
+// Priority: document_number (sanitized) > transaction_date > issue_date > 'undated'.
+// document_number wins because it is the most user-recognizable identifier and
+// is unique per invoice, matching how accounting teams file the paperwork.
+// transaction_date / issue_date are normalized to YYYYMMDD so the resulting
+// file name stays portable across filesystems.
+function buildFileNameSuffix(p) {
+  const fromDocNumber = sanitizeForFileName(p && p.document_number);
+  if (fromDocNumber) {
+    return fromDocNumber;
+  }
+  const fromTxDate = ymdCompact(p && p.transaction_date);
+  if (fromTxDate) {
+    return fromTxDate;
+  }
+  const fromIssueDate = ymdCompact(p && p.issue_date);
+  if (fromIssueDate) {
+    return fromIssueDate;
+  }
+  return 'undated';
+}
+
+function sanitizeForFileName(raw) {
+  if (typeof raw !== 'string') {
+    return '';
+  }
+  // Replace characters that are illegal on common filesystems (Windows, macOS,
+  // Linux) plus whitespace with underscores, collapse consecutive underscores,
+  // trim leading / trailing underscores, and cap the length to keep the final
+  // file name well below the typical 255-byte path limit once the prefix and
+  // extension are added.
+  const replaced = raw.replace(/[\\/:*?"<>|\s\x00-\x1f]/g, '_');
+  const collapsed = replaced.replace(/_+/g, '_');
+  const trimmed = collapsed.replace(/^_+|_+$/g, '');
+  if (trimmed.length === 0) {
+    return '';
+  }
+  return trimmed.length > 80 ? trimmed.slice(0, 80) : trimmed;
+}
+
+function ymdCompact(raw) {
+  if (typeof raw !== 'string') {
+    return '';
+  }
+  const match = raw.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (!match) {
+    return '';
+  }
+  return match[1] + match[2] + match[3];
+}

--- a/template.yaml
+++ b/template.yaml
@@ -13,6 +13,30 @@ template_prompt: |
   - `simplified_invoice`（適格簡易請求書：小売・飲食・タクシー・駐車場・旅行・写真業など）
   - `return_invoice`（適格返還請求書：値引き・返品・割戻しなどで対価を返還した場合）
 
+  ## 帳票生成フロー（最重要）
+
+  ユーザーからの入力 JSON が揃ったら、**個別 STF を手動で連結するのではなく、必ず以下の
+  ワークフローを利用**してください。ワークフロー経由なら validate → render の payload 受け渡しが
+  決定論的に行われるため、PDF / DOCX の中身が空になったり、ファイル名が `undated` に落ちる
+  ケースを避けられます。
+
+  - 両方（PDF + DOCX）欲しい場合の推奨手順:
+    1. まず `validate-qualified-invoice` を単体で 1 回呼び、`valid: false` なら `errors[]` を
+       日本語でユーザーに提示して修正を依頼する。勝手に値を補完して進めてはいけない。
+    2. `valid: true` なら、`generate-invoice-pdf` と `generate-invoice-docx` を**両方**呼ぶ
+       （順不同）。それぞれのワークフローが PDF / DOCX の `{file_data, file_name}` を返す。
+  - PDF だけで良い場合は `generate-invoice-pdf` のみ、DOCX だけで良い場合は
+    `generate-invoice-docx` のみを呼ぶ。
+  - 個別 STF（`render-invoice-pdf` / `render-invoice-docx`）を手動で呼ぶのは、ワークフローが
+    なんらかの理由で利用できない場合のみのフォールバックとする。手動で呼ぶときは必ず
+    `validate-qualified-invoice` の `normalized_payload` を render STF の `$input` に
+    そのまま渡す（部分的に抜き取ったりしない）。
+
+  ワークフロー実行後の戻り値は `{file_data, file_name}` 形式になっており、d6e の UI が
+  自動的にダウンロードリンクとして展開します。AI 側で base64 を貼り付ける必要はありません。
+  代わりに「PDF と DOCX をダウンロード可能な形で生成しました」といった一言と、必要に応じて
+  合計金額のサマリーなど次のアクション提案を添えてください。
+
   ## 利用フローの判別
 
   ユーザーの入力を見て、以下 3 つのモードのうち 1 つを選んでください。
@@ -20,7 +44,7 @@ template_prompt: |
   1. JSON ペーストモード（主運用）
      ユーザーの発言にコードブロックの JSON オブジェクトが含まれている、
      または「この JSON で」「下のデータで作って」と明示された場合。
-     その場合、JSON を そのままの構造で `validate-qualified-invoice` の入力に渡してください。
+     その JSON をそのままワークフローの入力として渡してください。
      不足項目や型不一致があった場合は、勝手に値を創作せず必ずユーザーに確認してください。
   2. テンプレ要求モード
      「雛形」「テンプレート」「入力フォーマット」「サンプル JSON」「どんな形で渡せば良い」
@@ -30,7 +54,8 @@ template_prompt: |
      「この内容をあなたの情報で編集して貼り戻してください」と案内してください。
   3. 対話フォールバックモード
      JSON の貼り付けもテンプレ要求もなく、自然文で依頼された場合。
-     下記「収集すべき項目」を一問一答で聞き、すべて揃ったら JSON にまとめてから次のステップに進みます。
+     下記「収集すべき項目」を一問一答で聞き、すべて揃ったら JSON にまとめてから
+     上記のワークフロー呼び出し手順に進みます。
 
   ## 収集すべき項目（対話フォールバック時の最小セット）
 
@@ -45,25 +70,18 @@ template_prompt: |
   7. （簡易の場合）6 は任意
   8. （返還の場合）返還事由と元の請求書番号（`return_info.reason` / `return_info.original_document_number`）
 
-  任意項目: 会社ロゴ (`issuer.logo`)、支払期限・振込先 (`payment.*`)、備考 (`notes`)、
-  税抜／税込の別 (`price_mode`)、端数処理 (`rounding_method`)。
+  任意項目: 書類番号 (`document_number`)、会社ロゴ (`issuer.logo`)、
+  支払期限・振込先 (`payment.*`)、備考 (`notes`)、税抜／税込の別 (`price_mode`)、
+  端数処理 (`rounding_method`)。
+  **ファイル名には `document_number` が優先的に使われる**ため、書類番号を指定すると
+  `適格請求書_INV-2026-001.pdf` のような分かりやすい名前になります。省略時は取引日、
+  それも無ければ `undated` にフォールバックします。
 
   ## document_type の決め方
 
   - 何も指定されなければ `qualified_invoice`
   - 「レシート」「小売」「飲食店」「タクシー」「駐車場」「旅行」などの文脈なら `simplified_invoice`
   - 「返品」「値引き」「割戻し」「返還」などが出たら `return_invoice`
-
-  ## STF 呼び出しの流れ
-
-  1. 入力が揃ったら、必ず最初に `validate-qualified-invoice` を呼んで記載要件を検証する。
-  2. 結果が `valid: false` なら、`errors[]` の内容をユーザーに日本語で提示し、修正を依頼して
-     もう一度最初から組み直す。勝手に値を補完して再実行してはいけない。
-  3. `valid: true` になったら、`validate-qualified-invoice` が返した `normalized_payload` を使って、
-     `render-invoice-pdf` と `render-invoice-docx` の両方を呼ぶ。ユーザーが明示的に片方だけを
-     希望した場合（「PDF だけで良い」など）のみ、指定された方だけを呼ぶ。
-  4. 生成された `file_data`（base64）と `file_name` は d6e の UI が自動的にダウンロードリンクとして
-     表示するので、AI 側で追加の説明は不要（ただし要約や次のアクションの提案は歓迎）。
 
   ## 出力時のマナー
 
@@ -75,6 +93,12 @@ template_prompt: |
     （想像で答えない）。
 
 stfs:
+  # NOTE: The three STFs below share the same input payload shape. If you change
+  # one input_schema you MUST update the other two to match. They are kept as
+  # verbatim copies here (rather than YAML anchors) because the d6e installer
+  # pipeline does not guarantee anchor expansion survives all re-serialization
+  # stages, and drift would silently break either validation or rendering.
+
   - name: validate-qualified-invoice
     runtime: js
     description: Validates six mandatory fields, registration number format, and computes per-tax-rate totals for a qualified invoice payload.
@@ -184,6 +208,7 @@ stfs:
     runtime: js
     description: Renders a validated invoice payload to an A4 PDF with embedded Japanese font. Returns base64 file_data and file_name.
     source: stfs/render-invoice-pdf.js
+    # Keep this schema synchronized with validate-qualified-invoice above.
     input_schema:
       type: object
       required:
@@ -198,11 +223,116 @@ stfs:
             - qualified_invoice
             - simplified_invoice
             - return_invoice
+        document_number:
+          type: string
+        transaction_date:
+          type: string
+          pattern: "^\\d{4}-\\d{2}-\\d{2}$"
+        issue_date:
+          type: string
+          pattern: "^\\d{4}-\\d{2}-\\d{2}$"
+        issuer:
+          type: object
+          required:
+            - name
+            - registration_number
+          properties:
+            name:
+              type: string
+            registration_number:
+              type: string
+              pattern: "^T\\d{13}$"
+            address:
+              type: string
+            contact:
+              type: string
+            logo:
+              type:
+                - object
+                - "null"
+              properties:
+                format:
+                  type: string
+                  enum: [png, jpg, jpeg]
+                data_base64:
+                  type: string
+        recipient:
+          type: object
+          properties:
+            name:
+              type: string
+            address:
+              type: string
+        items:
+          type: array
+          minItems: 1
+          items:
+            type: object
+            required:
+              - description
+              - quantity
+              - unit_price
+              - tax_rate
+            properties:
+              description:
+                type: string
+              quantity:
+                type: number
+              unit_price:
+                type: number
+              tax_rate:
+                type: number
+                enum: [0.08, 0.10]
+        price_mode:
+          type: string
+          enum: [tax_excluded, tax_included]
+          default: tax_excluded
+        rounding_method:
+          type: string
+          enum: [floor, ceil, round]
+          default: floor
+        payment:
+          type: object
+          properties:
+            due_date:
+              type: string
+            bank_info:
+              type: string
+        notes:
+          type: string
+        return_info:
+          type: object
+          properties:
+            original_document_number:
+              type: string
+            return_date:
+              type: string
+            reason:
+              type: string
+        totals:
+          type: object
+          description: Pre-computed totals from validate-qualified-invoice. Optional; render STF recomputes if absent.
+          properties:
+            subtotal_8:
+              type: number
+            subtotal_10:
+              type: number
+            subtotal:
+              type: number
+            tax_8:
+              type: number
+            tax_10:
+              type: number
+            tax_total:
+              type: number
+            grand_total:
+              type: number
 
   - name: render-invoice-docx
     runtime: js
     description: Renders a validated invoice payload to a Word (docx) document using MS Gothic. Returns base64 file_data and file_name.
     source: stfs/render-invoice-docx.js
+    # Keep this schema synchronized with validate-qualified-invoice above.
     input_schema:
       type: object
       required:
@@ -217,6 +347,110 @@ stfs:
             - qualified_invoice
             - simplified_invoice
             - return_invoice
+        document_number:
+          type: string
+        transaction_date:
+          type: string
+          pattern: "^\\d{4}-\\d{2}-\\d{2}$"
+        issue_date:
+          type: string
+          pattern: "^\\d{4}-\\d{2}-\\d{2}$"
+        issuer:
+          type: object
+          required:
+            - name
+            - registration_number
+          properties:
+            name:
+              type: string
+            registration_number:
+              type: string
+              pattern: "^T\\d{13}$"
+            address:
+              type: string
+            contact:
+              type: string
+            logo:
+              type:
+                - object
+                - "null"
+              properties:
+                format:
+                  type: string
+                  enum: [png, jpg, jpeg]
+                data_base64:
+                  type: string
+        recipient:
+          type: object
+          properties:
+            name:
+              type: string
+            address:
+              type: string
+        items:
+          type: array
+          minItems: 1
+          items:
+            type: object
+            required:
+              - description
+              - quantity
+              - unit_price
+              - tax_rate
+            properties:
+              description:
+                type: string
+              quantity:
+                type: number
+              unit_price:
+                type: number
+              tax_rate:
+                type: number
+                enum: [0.08, 0.10]
+        price_mode:
+          type: string
+          enum: [tax_excluded, tax_included]
+          default: tax_excluded
+        rounding_method:
+          type: string
+          enum: [floor, ceil, round]
+          default: floor
+        payment:
+          type: object
+          properties:
+            due_date:
+              type: string
+            bank_info:
+              type: string
+        notes:
+          type: string
+        return_info:
+          type: object
+          properties:
+            original_document_number:
+              type: string
+            return_date:
+              type: string
+            reason:
+              type: string
+        totals:
+          type: object
+          description: Pre-computed totals from validate-qualified-invoice. Optional; render STF recomputes if absent.
+          properties:
+            subtotal_8:
+              type: number
+            subtotal_10:
+              type: number
+            subtotal:
+              type: number
+            tax_8:
+              type: number
+            tax_10:
+              type: number
+            tax_total:
+              type: number
+            grand_total:
+              type: number
 
 files:
   - name: invoice-requirements-guide
@@ -230,3 +464,125 @@ files:
   - name: invoice-input-template
     description: Copy-and-edit JSON input templates for the three document types, containing placeholder values.
     path: files/invoice-input-template.json
+
+workflows:
+  # Two separate workflows because d6e workflow return values are limited to the
+  # last STF output (see packages/api/src/engine/workflow.rs), and the frontend
+  # binary-detection extracts only one file_data per tool result. Exposing one
+  # workflow per output format lets the AI call both when the user wants both.
+
+  - name: generate-invoice-pdf
+    description: Validates the payload and renders the invoice as a PDF in a single deterministic run. Returns { file_data, file_name } for the PDF.
+    stf_steps:
+      - stf_name: validate-qualified-invoice
+        input_mappings:
+          - source: { type: Variable, value: "$input.document_type" }
+            target: document_type
+          - source: { type: Variable, value: "$input.document_number" }
+            target: document_number
+          - source: { type: Variable, value: "$input.transaction_date" }
+            target: transaction_date
+          - source: { type: Variable, value: "$input.issue_date" }
+            target: issue_date
+          - source: { type: Variable, value: "$input.issuer" }
+            target: issuer
+          - source: { type: Variable, value: "$input.recipient" }
+            target: recipient
+          - source: { type: Variable, value: "$input.items" }
+            target: items
+          - source: { type: Variable, value: "$input.price_mode" }
+            target: price_mode
+          - source: { type: Variable, value: "$input.rounding_method" }
+            target: rounding_method
+          - source: { type: Variable, value: "$input.payment" }
+            target: payment
+          - source: { type: Variable, value: "$input.notes" }
+            target: notes
+          - source: { type: Variable, value: "$input.return_info" }
+            target: return_info
+      - stf_name: render-invoice-pdf
+        input_mappings:
+          - source: { type: Variable, value: "$steps[0].normalized_payload.document_type" }
+            target: document_type
+          - source: { type: Variable, value: "$steps[0].normalized_payload.document_number" }
+            target: document_number
+          - source: { type: Variable, value: "$steps[0].normalized_payload.transaction_date" }
+            target: transaction_date
+          - source: { type: Variable, value: "$steps[0].normalized_payload.issue_date" }
+            target: issue_date
+          - source: { type: Variable, value: "$steps[0].normalized_payload.issuer" }
+            target: issuer
+          - source: { type: Variable, value: "$steps[0].normalized_payload.recipient" }
+            target: recipient
+          - source: { type: Variable, value: "$steps[0].normalized_payload.items" }
+            target: items
+          - source: { type: Variable, value: "$steps[0].normalized_payload.price_mode" }
+            target: price_mode
+          - source: { type: Variable, value: "$steps[0].normalized_payload.rounding_method" }
+            target: rounding_method
+          - source: { type: Variable, value: "$steps[0].normalized_payload.payment" }
+            target: payment
+          - source: { type: Variable, value: "$steps[0].normalized_payload.notes" }
+            target: notes
+          - source: { type: Variable, value: "$steps[0].normalized_payload.return_info" }
+            target: return_info
+          - source: { type: Variable, value: "$steps[0].normalized_payload.totals" }
+            target: totals
+
+  - name: generate-invoice-docx
+    description: Validates the payload and renders the invoice as a Word (docx) document in a single deterministic run. Returns { file_data, file_name } for the DOCX.
+    stf_steps:
+      - stf_name: validate-qualified-invoice
+        input_mappings:
+          - source: { type: Variable, value: "$input.document_type" }
+            target: document_type
+          - source: { type: Variable, value: "$input.document_number" }
+            target: document_number
+          - source: { type: Variable, value: "$input.transaction_date" }
+            target: transaction_date
+          - source: { type: Variable, value: "$input.issue_date" }
+            target: issue_date
+          - source: { type: Variable, value: "$input.issuer" }
+            target: issuer
+          - source: { type: Variable, value: "$input.recipient" }
+            target: recipient
+          - source: { type: Variable, value: "$input.items" }
+            target: items
+          - source: { type: Variable, value: "$input.price_mode" }
+            target: price_mode
+          - source: { type: Variable, value: "$input.rounding_method" }
+            target: rounding_method
+          - source: { type: Variable, value: "$input.payment" }
+            target: payment
+          - source: { type: Variable, value: "$input.notes" }
+            target: notes
+          - source: { type: Variable, value: "$input.return_info" }
+            target: return_info
+      - stf_name: render-invoice-docx
+        input_mappings:
+          - source: { type: Variable, value: "$steps[0].normalized_payload.document_type" }
+            target: document_type
+          - source: { type: Variable, value: "$steps[0].normalized_payload.document_number" }
+            target: document_number
+          - source: { type: Variable, value: "$steps[0].normalized_payload.transaction_date" }
+            target: transaction_date
+          - source: { type: Variable, value: "$steps[0].normalized_payload.issue_date" }
+            target: issue_date
+          - source: { type: Variable, value: "$steps[0].normalized_payload.issuer" }
+            target: issuer
+          - source: { type: Variable, value: "$steps[0].normalized_payload.recipient" }
+            target: recipient
+          - source: { type: Variable, value: "$steps[0].normalized_payload.items" }
+            target: items
+          - source: { type: Variable, value: "$steps[0].normalized_payload.price_mode" }
+            target: price_mode
+          - source: { type: Variable, value: "$steps[0].normalized_payload.rounding_method" }
+            target: rounding_method
+          - source: { type: Variable, value: "$steps[0].normalized_payload.payment" }
+            target: payment
+          - source: { type: Variable, value: "$steps[0].normalized_payload.notes" }
+            target: notes
+          - source: { type: Variable, value: "$steps[0].normalized_payload.return_info" }
+            target: return_info
+          - source: { type: Variable, value: "$steps[0].normalized_payload.totals" }
+            target: totals


### PR DESCRIPTION
Closes #5.

## Summary

End-to-end re-testing after the v1.0.0 download-UI fix confirmed that
files *were* being delivered to the browser, but the PDF body was
essentially empty (all totals `¥0`, no document number, no dates) and
the filename fell back to `適格請求書_undated.pdf` even when a proper
document number was supplied. The AI agent was also observed calling
the three STFs manually and sometimes forgetting to run the renderer
for one of the formats. Root cause: the app had no deterministic
workflow, render STF schemas were a near-empty stub, and the filename
logic only looked at `transaction_date`.

This PR addresses the three items the tester prioritized, in order.

### 1. `render-invoice-pdf` payload reception and file name

- Both render STFs now unwrap `$input.normalized_payload` when the
  caller forwards the full validator response, so the downstream code
  (which expects a flat payload) always sees populated fields.
- File name generation is now shared between PDF and DOCX and follows
  the ladder: `document_number` (sanitized for filesystem-illegal chars
  and capped at 80 chars) → `transaction_date` → `issue_date` →
  `undated`. Downloads now surface as
  `適格請求書_INV-TEST-20260422-004.pdf` for the failing test case.

### 2. Workflows that guarantee PDF + DOCX delivery

- Added two workflows, `generate-invoice-pdf` and
  `generate-invoice-docx`. Each workflow chains
  `validate-qualified-invoice → render-invoice-<format>` with explicit
  `input_mappings` (`\$input.<field>` into the validator,
  `\$steps[0].normalized_payload.<field>` into the renderer).
- Separate workflows per format are required because
  [d6e's `execute_workflow`](https://github.com/d6e-ai/d6e/blob/main/packages/api/src/engine/workflow.rs)
  only returns the last STF output, and the frontend binary detector
  extracts a single `file_data` per tool result. Exposing one workflow
  per format lets the AI call both when the user asks for both files,
  which is what `template_prompt` now instructs.

### 3. Unified input shape for all three STFs

- Expanded `input_schema` of both render STFs from a four-field stub to
  the full payload shape (kept byte-identical with
  `validate-qualified-invoice`). This gives LLM tool-callers complete
  field-level hints and lets runtime schema validation catch missing
  required fields before rendering.
- Added a `totals` object to the render schemas so the precomputed
  totals produced by validator flow through workflow `input_mappings`.

## Verification

- `ajv` validation against `d6e-app-skills/schema/template.schema.json`
  passes.
- STF syntax check (`new Function(...)`-based wrapper in
  `/tmp/d6e-validate/check-stfs.js`) passes for all three STFs.
- New filename logic unit-tested against 12 scenarios
  (`document_number` wins, filesystem-illegal chars replaced, blank
  falls through, long names capped, invalid date rejected, missing
  fields all yield `undated`, etc.).

## Test plan

- [ ] Reinstall `d6e/invoice-jp` v1.0.0 in a fresh workspace after the
      next version bump / republish cycle.
- [ ] Paste the previously failing JSON and ask for both PDF and DOCX.
      Expect the AI to run `validate-qualified-invoice` once, then call
      `generate-invoice-pdf` and `generate-invoice-docx`.
- [ ] Confirm both downloads appear as
      `適格請求書_INV-TEST-20260422-004.{pdf,docx}` and that opening
      the PDF in Chrome shows the populated body (document number,
      issue date, transaction date, line items, per-rate tax totals,
      grand total of ¥113,888).
- [ ] Repeat with `simplified_invoice` and `return_invoice` inputs to
      verify the `document_number` → date → undated fallback ladder
      works for those document types too.

## Non-goals

- Simultaneous PDF + DOCX return from a single workflow — this would
  require d6e core changes (workflow return value aggregation + UI
  multi-attachment extraction).
- Parallel execution of render steps — d6e currently runs STF steps
  sequentially in a workflow.
- End-to-end retest with `simplified_invoice` / `return_invoice` is
  tracked as a follow-up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes tool invocation paths (`template.yaml` workflows/mappings and schemas) and rendering input handling, which can affect invoice generation behavior across both PDF and DOCX outputs.
> 
> **Overview**
> **Fixes blank/¥0 invoice renders and inconsistent downloads** by making `render-invoice-pdf`/`render-invoice-docx` unwrap `$input.normalized_payload` (when the full validator result is forwarded) and by generating file names via `document_number` (sanitized/capped) with fallbacks to `transaction_date`, `issue_date`, then `undated`.
> 
> **Introduces deterministic generation paths** by adding two workflows, `generate-invoice-pdf` and `generate-invoice-docx`, that chain `validate-qualified-invoice` → the corresponding renderer with explicit `$input`/`$steps[0].normalized_payload` mappings, and updates `template_prompt` to prefer these workflows over manual STF chaining.
> 
> **Expands and aligns renderer `input_schema`** to the full invoice payload (including optional `totals`) and adds sync-comments to reduce schema drift; `CHANGELOG.md` documents the fixes and new workflows, and a new planning doc captures the rationale.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18c6792411d7fc56169eaec4c81eea85edc2f5ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->